### PR TITLE
[FEAT] 라우터 경로 변경 및 레이아웃 설정 (#9)

### DIFF
--- a/src/common/Navbar.js
+++ b/src/common/Navbar.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Outlet } from 'react-router-dom';
 
 function Navbar(props) {
   return (
     <div>
       Navbar
-      <Outlet />
     </div>
   );
 }

--- a/src/layout/MainLayout.js
+++ b/src/layout/MainLayout.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+import { styled } from '@mui/system';
+import Navbar from '../common/Navbar';
+
+const MainLayoutBlock = styled('div')(({theme}) => ({
+    background : theme.palette.bg,
+    width : '1440px',
+    margin : '0 auto'
+}))
+
+function MainLayout(props) {
+    return (
+        <MainLayoutBlock>
+            <Navbar />
+            <Outlet />
+        </MainLayoutBlock>
+    );
+}
+
+export default MainLayout;

--- a/src/pages/NotFoundPage.js
+++ b/src/pages/NotFoundPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function NotFoundPage(props) {
+    return (
+        <div>
+            404
+        </div>
+    );
+}
+
+export default NotFoundPage;

--- a/src/router.js
+++ b/src/router.js
@@ -1,70 +1,66 @@
-import { useRoutes } from "react-router-dom";
-import Navbar from "./common/Navbar";
-import MainPage from "./pages/MainPage";
-import DeviceOrderHistoryPage from "./pages/order/DeviceOrderHistoryPage";
-import DeviceOrderPage from "./pages/order/DeviceOrderPage";
-import DeviceDetailPage from "./pages/product/DeviceDetailPage";
-import DeviceListPage from "./pages/product/DeviceListPage";
-import SearchResultPage from "./pages/SearchResultPage";
+import { Navigate, useRoutes } from 'react-router-dom';
+
+import MainLayout from './layout/MainLayout';
+import MainPage from './pages/MainPage';
+import NotFoundPage from './pages/NotFoundPage';
+import DeviceOrderHistoryPage from './pages/order/DeviceOrderHistoryPage';
+import DeviceOrderPage from './pages/order/DeviceOrderPage';
+import DeviceDetailPage from './pages/product/DeviceDetailPage';
+import DeviceListPage from './pages/product/DeviceListPage';
+import SearchResultPage from './pages/SearchResultPage';
 
 function Router() {
-    return useRoutes([
+  return useRoutes([
+    {
+      path: '',
+      element: <MainLayout />,
+      children: [
         {
-            path : "",
-            element : <Navbar />,
-            children : [
-                {
-                    path : "",
-                    element : <MainPage />
-                },
-                {
-                    path : '5g-phone',
-                    element : <DeviceListPage />,
-                    children : [
-                        {
-                            path : 'samsung/:id',
-                            element : <DeviceDetailPage />
-                        },
-                        {
-                            path : 'apple/:id',
-                            element : <DeviceDetailPage />
-                        }
-                    ]
-                },
-                {
-                    path : '4g-phone',
-                    element : <DeviceListPage />,
-                    children : [
-                        {
-                            path : 'samsung/:id',
-                            element : <DeviceDetailPage />
-                        },
-                        {
-                            path : 'apple/:id',
-                            element : <DeviceDetailPage />
-                        }
-                    ]
-                },
-                {
-                    path : 'search/result',
-                    element : <SearchResultPage />
-                },
-                {
-                    path : 'order',
-                    children : [
-                        {
-                            path : 'mobile',
-                            element : <DeviceOrderPage />
-                        },
-                        {
-                            path : ':id',
-                            element : <DeviceOrderHistoryPage />
-                        }
-                    ]
-                }
-            ]
-        }
-    ])
+          path: '',
+          element: <MainPage />,
+        },
+        {
+          path: '5g-phone',
+          element: <DeviceListPage />,
+          children: [
+            {
+              path: ':id',
+              element: <DeviceDetailPage />,
+            },
+          ],
+        },
+        {
+          path: '4g-phone',
+          element: <DeviceListPage />,
+          children: [
+            {
+              path: ':id',
+              element: <DeviceDetailPage />,
+            }
+          ],
+        },
+        {
+          path: 'search/result',
+          element: <SearchResultPage />,
+        },
+        {
+          path: 'order',
+          children: [
+            {
+              path: 'mobile',
+              element: <DeviceOrderPage />,
+            },
+            {
+              path: ':id',
+              element: <DeviceOrderHistoryPage />,
+            },
+          ],
+        },
+        { path: '/404', element: <NotFoundPage /> },
+      ],
+    },
+    { path: '*', element: <Navigate to="/404" replace /> },
+  ]);
 }
 
 export default Router;


### PR DESCRIPTION
## 📌 개발 내용
- resolve #{9}
- 라우터 경로 변경 및 레이아웃 설정
  <br>

## 💻  변경 내용
- 기기 제조사별 분리된 라우터를 하나로 합쳤습니다.
- 메인 레이아웃을 설정하였습니다.
- NotFoundPage를 생성하여 유효하지 않은 페이지 접근 시 /404로 이동하게 하였습니다.
  <br>
