### PR TITLE
✨ 상품리스트 필터 label과 checkbox 연동 및 정렬 탭 구현 (#23)

### DIFF
--- a/src/components/device/DeviceList.js
+++ b/src/components/device/DeviceList.js
@@ -16,18 +16,15 @@ const DeviceListWrapper = styled(Box)({
 });
 
 function DeviceList() {
+  const datas = Array.from({ length: 32 });
+  console.log(datas);
   return (
     <DeviceListBlock>
       <DeviceListHeader />
       <DeviceListWrapper>
-        <DeviceListItem />
-        <DeviceListItem />
-        <DeviceListItem />
-        <DeviceListItem />
-        <DeviceListItem />
-        <DeviceListItem />
-        <DeviceListItem />
-        <DeviceListItem />
+        {datas.map((data) => (
+          <DeviceListItem />
+        ))}
       </DeviceListWrapper>
     </DeviceListBlock>
   );

--- a/src/components/device/DeviceListFileterContents.js
+++ b/src/components/device/DeviceListFileterContents.js
@@ -1,4 +1,4 @@
-export const PaymentType = [
+export const PAYMENT_TYPE = [
   {
     name: '가장 알맞은 요금제',
     value: 'recommend',
@@ -17,7 +17,7 @@ export const PaymentType = [
   },
 ];
 
-export const DiscountType = [
+export const DISCOUNT_TYPE = [
   {
     name: '추천',
     value: 'recommend',
@@ -36,7 +36,7 @@ export const DiscountType = [
   },
 ];
 
-export const Company = [
+export const COMPANY = [
   {
     name: '전체',
     value: 'all',
@@ -55,7 +55,7 @@ export const Company = [
   },
 ];
 
-export const Storage = [
+export const STORAGE = [
   {
     name: '전체',
     value: 'all',
@@ -73,3 +73,9 @@ export const Storage = [
     value: '256gb',
   },
 ];
+
+export const PRICE_CONFIG = {
+  MIN: 0,
+  MAX: 200000,
+  STEP: 1000,
+};

--- a/src/components/device/DeviceListFilter.js
+++ b/src/components/device/DeviceListFilter.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import * as FilterData from './DeviceListFileterContents';
+import * as FILTER_DATA from './DeviceListFileterContents';
 
 import { styled } from '@mui/system';
 import {
@@ -23,11 +23,7 @@ import {
 } from '@mui/icons-material';
 
 const DeviceListFilterBlock = styled('div')(({ theme }) => ({
-  position: 'sticky',
-  top: 0,
   minWidth: 240,
-  height: 340,
-  background: theme.palette.gray1,
   '& .MuiListItemButton-root': {
     padding: '0 5px',
   },
@@ -40,6 +36,30 @@ const DeviceListFilterBlock = styled('div')(({ theme }) => ({
   '& .list-type-label': {
     cursor: 'pointer',
   },
+}));
+
+// TODO - sticky 적용시 하단에 공백 생성됨 : maxHeight때문
+const StyledListFilter = styled(List)(({ theme }) => ({
+  background: theme.palette.gray1,
+  position: 'sticky',
+  top: '60px',
+  overflowX: 'hidden',
+  overflowY: 'auto',
+  maxHeight: 'calc(100vh - 150px)',
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
+  // '&:hover::-webkit-scrollbar': {
+  //   width: '10px',
+  // },
+  // '&::-webkit-scrollbar-thumb': {
+  //   background: theme.palette.gray3,
+  //   borderRadius: 50,
+  // },
+  // '&::-webkit-scrollbar-track': {
+  //   background: theme.palette.gray2,
+  //   borderRadius: 50,
+  // },
 }));
 
 const StyledCheckbox = styled(Checkbox)(({ theme }) => ({
@@ -60,10 +80,15 @@ function printPriceRange(value) {
   return `${value[0].toLocaleString('ko-KR')}원 ~ ${value[1].toLocaleString('ko-KR')}원`;
 }
 
-// TODO - 필터 라벨 눌러도 체크되도록 설정
-function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onChangeCheckbox }) {
+function DeviceListFilter({
+  paymentType,
+  discountType,
+  price,
+  multiCheckbox,
+  onChangeCheckbox,
+  onChangeSlider,
+}) {
   const [open, setOpen] = useState([true, true, true, false, false]);
-
   const handleClickListOpen = (idx) => {
     const newOpen = [...open];
     newOpen[idx] = !newOpen[idx];
@@ -72,7 +97,7 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
 
   return (
     <DeviceListFilterBlock>
-      <List component="nav">
+      <StyledListFilter component="nav">
         {/* 요금제 */}
         <ListItem className="list-type-label" onClick={() => handleClickListOpen(0)}>
           <ListItemText primary="요금제" />
@@ -81,8 +106,11 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
         <Divider />
         <Collapse in={open[0]} timeout="auto" unmountOnExit>
           <List component="div">
-            {FilterData.PaymentType.map((type) => (
-              <ListItemButton dense onClick={() => onChangeCheckbox('payment', type.value)}>
+            {FILTER_DATA.PAYMENT_TYPE.map((type) => (
+              <ListItemButton
+                key={type.value}
+                dense
+                onClick={() => onChangeCheckbox('payment', type.value)}>
                 <ListItemIcon>
                   <StyledCheckbox
                     checked={paymentType === type.value}
@@ -104,8 +132,11 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
         <Divider />
         <Collapse in={open[1]} timeout="auto" unmountOnExit>
           <List component="div">
-            {FilterData.DiscountType.map((type) => (
-              <ListItemButton dense onClick={() => onChangeCheckbox('discount', type.value)}>
+            {FILTER_DATA.DISCOUNT_TYPE.map((type) => (
+              <ListItemButton
+                key={type.value}
+                dense
+                onClick={() => onChangeCheckbox('discount', type.value)}>
                 <ListItemIcon>
                   <StyledCheckbox
                     checked={discountType === type.value}
@@ -131,12 +162,12 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
                 <StyledSlider
                   value={price}
                   getAriaLabel={() => 'Price'}
-                  min={0}
-                  max={200000}
-                  step={1000}
-                  defaultValue={[20, 37]}
+                  min={FILTER_DATA.PRICE_CONFIG.MIN}
+                  max={FILTER_DATA.PRICE_CONFIG.MAX}
+                  step={FILTER_DATA.PRICE_CONFIG.STEP}
+                  defaultValue={[FILTER_DATA.PRICE_CONFIG.MIN, FILTER_DATA.PRICE_CONFIG.MAX]}
                   valueLabelDisplay="off"
-                  // onChange={handleChangePriceRange}
+                  onChange={onChangeSlider}
                   valueLabelFormat={valueLabelFormat}
                 />
               </Stack>
@@ -152,14 +183,16 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
         <Divider />
         <Collapse in={open[3]} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
-            {FilterData.Company.map((type) => (
-              <ListItemButton dense>
+            {FILTER_DATA.COMPANY.map((type) => (
+              <ListItemButton
+                key={type.value}
+                dense
+                onClick={(e) => onChangeCheckbox('company', type.value)}>
                 <ListItemIcon>
                   <StyledCheckbox
                     checked={multiCheckbox.company.has(type.value)}
                     icon={<RadioButtonUnchecked />}
                     checkedIcon={<RadioButtonChecked />}
-                    onChange={(e) => onChangeCheckbox('company', type.value, e.target.checked)}
                   />
                 </ListItemIcon>
                 <ListItemText primary={type.name} />
@@ -176,14 +209,16 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
         <Divider />
         <Collapse in={open[4]} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
-            {FilterData.Storage.map((type) => (
-              <ListItemButton dense onClick={(e) => onChangeCheckbox('storage', type.value, e)}>
+            {FILTER_DATA.STORAGE.map((type) => (
+              <ListItemButton
+                key={type.value}
+                dense
+                onClick={(e) => onChangeCheckbox('storage', type.value)}>
                 <ListItemIcon>
                   <StyledCheckbox
                     checked={multiCheckbox.storage.has(type.value)}
                     icon={<RadioButtonUnchecked />}
                     checkedIcon={<RadioButtonChecked />}
-                    // onChange={(e) => onChangeCheckbox('storage', type.value, e.target.checked)}
                   />
                 </ListItemIcon>
                 <ListItemText primary={type.name} />
@@ -191,7 +226,7 @@ function DeviceListFilter({ paymentType, discountType, price, multiCheckbox, onC
             ))}
           </List>
         </Collapse>
-      </List>
+      </StyledListFilter>
     </DeviceListFilterBlock>
   );
 }

--- a/src/components/device/DeviceListHeader.js
+++ b/src/components/device/DeviceListHeader.js
@@ -7,7 +7,12 @@ import {
   TextField,
   Stack,
   Checkbox,
-  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Menu,
+  MenuItem,
+  ListItemIcon,
 } from '@mui/material';
 import {
   ExpandMore,
@@ -22,6 +27,9 @@ const DeviceListHeaderBlock = styled('div')({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  '& .MuiListItemIcon-root': {
+    minWidth: 0,
+  },
 });
 
 const StyledDeviceSearchInput = styled(TextField)(({ theme }) => ({
@@ -49,9 +57,51 @@ const StyledCheckbox = styled(Checkbox)(({ theme }) => ({
   },
 }));
 
+const StyledSortWapper = styled('div')(({ theme }) => ({
+  '& .MuiButtonBase-root.MuiListItem-root:hover': {
+    background: 'none',
+    color: theme.palette.prime,
+  },
+  '& .MuiListItemIcon-root': {
+    marginLeft: 5,
+  },
+  '& .MuiListItemIcon-root:hover': {
+    background: theme.palette.gray2,
+    borderRadius: '100%',
+  },
+}));
+
+const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
+  '&.Mui-selected': {
+    background: 'rgba(230, 0, 126, 0.08)',
+    color: theme.palette.prime,
+  },
+  '&.Mui-selected:hover': {
+    background: 'rgba(230, 0, 126, 0.08)',
+  },
+}));
+
+const options = ['출시순', '실구매가순', '정상가순'];
+
 // TODO - 정렬 hover시 dropdown 구현
 function DeviceListHeader() {
   const [sort, setSort] = useState(true); // 정렬 기준 (true : 내림차순, false : 오름차순)
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedIndex, setSelectedIndex] = useState(1);
+  const open = Boolean(anchorEl);
+  const handleClickListItem = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuItemClick = (event, index) => {
+    setSelectedIndex(index);
+    setAnchorEl(null);
+    setSort(true);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   // TODO - 성능개선
   const handleChangeSortDirection = () => {
@@ -60,7 +110,7 @@ function DeviceListHeader() {
 
   return (
     <DeviceListHeaderBlock>
-      <Typography>전체 32건</Typography>
+      <div>전체 32건</div>
       <Stack direction="row" alignItems="center" spacing={3.5}>
         <StyledDeviceSearchInput
           InputProps={{
@@ -81,10 +131,44 @@ function DeviceListHeader() {
             label="정상가 보기"
           />
         </Stack>
-        <Stack direction="row" alignItems="center" onClick={handleChangeSortDirection}>
+        <StyledSortWapper>
+          <List component="nav" aria-label="Device sort settings">
+            <ListItem
+              button
+              disableRipple
+              id="lock-button"
+              aria-haspopup="listbox"
+              aria-controls="lock-menu"
+              aria-expanded={open ? 'true' : undefined}>
+              <ListItemText primary={options[selectedIndex]} onClick={handleClickListItem} />
+              <ListItemIcon onClick={handleChangeSortDirection}>
+                {sort ? <ExpandMore /> : <ExpandLess />}
+              </ListItemIcon>
+            </ListItem>
+          </List>
+          <Menu
+            id="lock-menu"
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleClose}
+            MenuListProps={{
+              'aria-labelledby': 'lock-button',
+              role: 'listbox',
+            }}>
+            {options.map((option, index) => (
+              <StyledMenuItem
+                key={option}
+                selected={index === selectedIndex}
+                onClick={(event) => handleMenuItemClick(event, index)}>
+                {option}
+              </StyledMenuItem>
+            ))}
+          </Menu>
+        </StyledSortWapper>
+        {/* <Stack direction="row" alignItems="center" onClick={handleChangeSortDirection}>
           <label>출시순</label>
           {sort ? <ExpandMore /> : <ExpandLess />}
-        </Stack>
+        </Stack> */}
       </Stack>
     </DeviceListHeaderBlock>
   );

--- a/src/pages/product/DeviceListPage.js
+++ b/src/pages/product/DeviceListPage.js
@@ -2,27 +2,38 @@ import React, { useState } from 'react';
 
 import DeviceList from '../../components/device/DeviceList';
 import DeviceListFilter from '../../components/device/DeviceListFilter';
+import { PRICE_CONFIG } from '../../components/device/DeviceListFileterContents';
 
 import { styled } from '@mui/system';
 import { Box } from '@mui/system';
+
+const Title = styled('h2')({
+  paddingTop: 30,
+  paddingBottom: 10,
+});
 
 const DeviceListWrapper = styled(Box)({
   display: 'flex',
   gap: 32,
 });
 
-function DeviceListPage(props) {
+function DeviceListPage() {
+  /* DeviceListHeader */
+  // const [sort, setSort] = useState(true); // 정렬 기준 (true : 내림차순, false : 오름차순)
+  // const [hasSoldout, setHasSoldout] = useState(false); // 품절 제외 여부 (true : 품절 제외, false : 품절 포함)
+  // const [showOriginPrice, setShowOriginPrice] = useState(false); // 정상가 보기 여부 (true : 정상가 보기, false : 정상가 숨기기)
+
+  /* DeviceListFilter */
   const [paymentType, setPaymentType] = useState('recommend'); // default : 가장 알맞은 요금제, 한개만 선택 가능
   const [discountType, setDiscountType] = useState('recommend'); // default : 추천, 한개만 선택 가능
-  const [price, setPrice] = useState([0, 200000]);
+  const [price, setPrice] = useState([PRICE_CONFIG.MIN, PRICE_CONFIG.MAX]);
   const [multiCheckbox, setMultiCheckbox] = useState({
     company: new Set(['all']),
     storage: new Set(['all']),
   });
 
   // 체크박스 선택시 값이 변경되는 함수
-  const handleCheckbox = (type, value, isChecked) => {
-    console.log(type, value, isChecked);
+  const handleChangeCheckbox = (type, value) => {
     if (type === 'payment') {
       setPaymentType(value);
     } else if (type === 'discount') {
@@ -30,6 +41,7 @@ function DeviceListPage(props) {
     } else if (type === 'company' || type === 'storage') {
       // 전체를 선택했는데, 두번 클릭(해지)한 경우 : 변화 없음
       const newTemp = new Set([...multiCheckbox[type]]);
+      const isChecked = !newTemp.has(value); // 이미 선택이 되어있는지 확인
       if (value === 'all' && isChecked) {
         newTemp.clear();
         newTemp.add(value);
@@ -61,16 +73,21 @@ function DeviceListPage(props) {
     }
   };
 
+  const handleChangeSlider = (e, value) => {
+    setPrice(value);
+  };
+
   return (
     <div>
-      <h2>5G 휴대폰</h2>
+      <Title>5G 휴대폰</Title>
       <DeviceListWrapper>
         <DeviceListFilter
           paymentType={paymentType}
           discountType={discountType}
           price={price}
           multiCheckbox={multiCheckbox}
-          onChangeCheckbox={handleCheckbox}
+          onChangeCheckbox={handleChangeCheckbox}
+          onChangeSlider={handleChangeSlider}
         />
         <DeviceList />
       </DeviceListWrapper>


### PR DESCRIPTION
## 📌 개발 내용
- resolve #23 
- 상품리스트 필터 label과 checkbox 연동 및 정렬 탭 구현 
  <br>

## 💻  변경 내용
- 상품리스트 필터에서 label 클릭 시 checkbox가 checked/unchecked 됩니다.
- 상품리스트 헤더의 정렬 탭 클릭 시 메뉴가 dropdown 되며, 화살표 아이콘 클릭 시 오름차순/내림차순이 변경됩니다.
- 상품리스트 필터가 sticky되도록 구현하며, scrollbar를 숨겼습니다.
  <br>
