### PR TITLE
[FEAT] 장바구니 페이지 레아아웃 구현 (#54)

### DIFF
--- a/src/components/cart/CartLIstItem.js
+++ b/src/components/cart/CartLIstItem.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import { styled } from '@mui/system';
+
+import RoundBtn from '../common/RoundBtn';
+
+const CartLIstItemBlock = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '20px 0',
+  position: 'relative',
+
+  '&::before': {
+    content: "''",
+    width: '100%',
+    height: 1,
+    display: 'block',
+    background: theme.palette.gray2,
+    position: 'absolute',
+    top: 0,
+  },
+
+  '&:first-child': {
+    '&::before': {
+      display: 'none',
+    },
+  },
+}));
+
+const DeviceWapper = styled('div')({});
+
+const ImageWapper = styled('div')({
+  width: 120,
+  heigth: 120,
+  marginRight: 25,
+
+  '& img': {
+    width: '100%',
+    height: '100%',
+  },
+});
+
+const DeviceInfoWapper = styled('div')(({ theme }) => ({
+  flex: 1,
+  '&  p:nth-of-type(1)': {
+    fontSize: '0.75rem',
+  },
+  '&  p:nth-of-type(2)': {
+    fontSize: '1.5rem',
+    fontWeight: 600,
+  },
+  '& p:nth-of-type(4)': {
+    marginTop: 15,
+    display: 'flex',
+
+    '& span::after': {
+      content: "''",
+      width: 1,
+      height: 15,
+      background: theme.palette.gray3,
+      display: 'inline-block',
+      margin: '0 10px',
+      verticalAlign: 'middle',
+    },
+
+    '& span:last-child::after': {
+      display: 'none',
+    },
+  },
+}));
+
+const DetailWapper = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  margin: ' 0 80px',
+
+  '& > div:first-child': {
+    paddingRight: 40,
+  },
+
+  '& > div:last-child': {
+    paddingLeft: 40,
+    position: 'relative',
+    '&::before': {
+      content: "''",
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      bottom: 0,
+      display: 'block',
+      width: 1,
+      height: 56,
+      margin: 'auto 0',
+      background: theme.palette.gray3,
+    },
+    'p:last-child': {
+      fontSize: '1.875rem',
+      fontWeight: 'bold',
+    },
+  },
+}));
+
+const OrderWapper = styled('div')({
+  fontSize: '1rem',
+});
+
+const imgsrc =
+  'https://image.lguplus.com/static/pc-contents/images/prdv/20220812-020618-663-OMVftJP5.jpg';
+
+function CartLIstItem() {
+  return (
+    <CartLIstItemBlock>
+      <ImageWapper>
+        <img src={imgsrc} alt="" />
+      </ImageWapper>
+      <DeviceInfoWapper>
+        <p>2022년 8월 30일 (화)</p>
+        <p>갤럭시 Z Flip 4</p>
+        <p>(갤럭시워치5G) 5G 다이렉트 65</p>
+        <p>
+          <span>보라퍼플</span>
+          <span>256GB</span>
+          <span>24개월 할부</span>
+        </p>
+      </DeviceInfoWapper>
+      <DetailWapper>
+        <div>
+          <span>기기변경</span>
+        </div>
+        <div>
+          <p>월 예상 납부 금액</p>
+          <p>124,900원</p>
+        </div>
+      </DetailWapper>
+      <OrderWapper>
+        <RoundBtn content="가입하기" padding="6px 50px" />
+      </OrderWapper>
+    </CartLIstItemBlock>
+  );
+}
+
+export default CartLIstItem;

--- a/src/components/cart/CartList.js
+++ b/src/components/cart/CartList.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { styled } from '@mui/system';
+import CartListEmpty from './CartListEmpty';
+import CartLIstItem from './CartLIstItem';
+
+const CartListBlock = styled('div')({});
+
+function CartList() {
+  return (
+    <CartListBlock>
+      <CartLIstItem />
+      <CartLIstItem />
+      <CartLIstItem />
+      {/* <CartListEmpty /> */}
+    </CartListBlock>
+  );
+}
+
+export default CartList;

--- a/src/components/cart/CartListEmpty.js
+++ b/src/components/cart/CartListEmpty.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { styled } from '@mui/system';
+import { ErrorOutline } from '@mui/icons-material';
+
+import RoundBtn from '../common/RoundBtn';
+
+const CartListEmptyBlock = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: 10,
+  padding: '100px 0',
+});
+
+const EmptyIconWapper = styled('div')(({ theme }) => ({
+  '& svg': {
+    fontSize: 64,
+    color: theme.palette.gray3,
+  },
+}));
+
+const EmptyPharse = styled('div')({
+  fontSize: 24,
+});
+
+const ButtonWapper = styled('div')({
+  marginTop: 20,
+});
+
+function CartListEmpty() {
+  return (
+    <CartListEmptyBlock>
+      <EmptyIconWapper>
+        <ErrorOutline />
+      </EmptyIconWapper>
+      <EmptyPharse>장바구니에 담은 상품이 없습니다.</EmptyPharse>
+      <ButtonWapper>
+        <RoundBtn content="상품 둘러보기" padding="10px 35px" />
+      </ButtonWapper>
+    </CartListEmptyBlock>
+  );
+}
+
+export default CartListEmpty;

--- a/src/components/common/RoundBtn.js
+++ b/src/components/common/RoundBtn.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/system';
 import { Button } from '@mui/material';
 
-const RoundBtnBlock = styled('div')({});
 const CustomButton = styled(Button)(({ theme }) => ({
   fontFamily: 'LGSmart',
   color: '#FFF',
@@ -20,6 +19,7 @@ function RoundBtn({
   content,
   backgroundColor = '',
   color = '',
+  border = '',
   disabled = false,
   width = '',
   height = '',
@@ -32,6 +32,7 @@ function RoundBtn({
       sx={{
         backgroundColor: backgroundColor,
         color: color,
+        border: border,
         width: width,
         padding: padding,
         minWidth: 'fit-content',

--- a/src/pages/cart/CartListPage.js
+++ b/src/pages/cart/CartListPage.js
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import { Box, Tab, Tabs } from '@mui/material';
+import React, { useState } from 'react';
+import CartList from '../../components/cart/CartList';
+
+const Title = styled('h1')({
+  paddingTop: 30,
+  paddingBottom: 10,
+  fontWeight: 'normal',
+  fontSize: 40,
+});
+
+const CountTab = styled('div')({
+  color: 'gray',
+});
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+  borderBottom: `1px solid ${theme.palette.gray3}`,
+
+  '& .MuiTabs-indicator': {
+    background: theme.palette.prime,
+  },
+  '& .MuiTab-root.Mui-selected': {
+    color: theme.palette.prime,
+    fontSize: 24,
+    fontWeight: 600,
+  },
+}));
+
+function CartListPage() {
+  const [value, setValue] = useState('mobile');
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <div>
+      <Title>장바구니</Title>
+      <Box sx={{ padding: '20px 0' }}>
+        <StyledTabs value={value} onChange={handleChange}>
+          <Tab value="mobile" label="모바일 기기" />
+        </StyledTabs>
+      </Box>
+      <CountTab>전체 3개</CountTab>
+      <CartList />
+    </div>
+  );
+}
+
+export default CartListPage;

--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,7 @@ import DeviceOrderPage from './pages/order/DeviceOrderPage';
 import DeviceDetailPage from './pages/product/DeviceDetailPage';
 import DeviceListPage from './pages/product/DeviceListPage';
 import SearchResultPage from './pages/SearchResultPage';
+import CartListPage from './pages/cart/CartListPage';
 
 function Router() {
   return useRoutes([
@@ -61,6 +62,10 @@ function Router() {
               element: <DeviceOrderHistoryPage />,
             },
           ],
+        },
+        {
+          path: 'cart',
+          element: <CartListPage />,
         },
         { path: '/404', element: <NotFoundPage /> },
       ],


### PR DESCRIPTION
## 📌 개발 내용
- resolve #54 
- 장바구니 페이지 레아아웃 구현
  <br>

## 💻  변경 내용
- /cart 장바구니 라우터가 추가되었습니다.
- 장바구니 페이지 레이아웃을 구현했습니다.
  <br>
