### PR TITLE
[REFACTOR] 상품 페이지 리스트 정렬 방향 버튼 및 출시 예정 단말기 디자인 수정

### DIFF
--- a/src/components/common/ScrollTopBtn.js
+++ b/src/components/common/ScrollTopBtn.js
@@ -11,11 +11,11 @@ const ScrollTopBtnBlock = styled('div')({
 const StyledFab = styled(Fab)(({ theme }) => ({
   width: 40,
   height: 40,
-  background: theme.palette.prime + '50',
+  background: '#ffa4d6',
   color: theme.palette.prime,
 
   '&:hover': {
-    background: theme.palette.prime + '70',
+    background: '#ff89ca',
   },
 }));
 

--- a/src/components/device/DeviceList.js
+++ b/src/components/device/DeviceList.js
@@ -32,7 +32,6 @@ const ErrorWarpper = styled('div')({
 
 function DeviceList({
   devices,
-  launchingDevices,
   loading,
   error,
   count,
@@ -42,9 +41,6 @@ function DeviceList({
   setExcludeSoldout,
   showPrice,
   setShowPrice,
-  sortby,
-  sortbyDir,
-  setSortbyDir,
   search,
   onChangeSearch,
 }) {
@@ -66,8 +62,6 @@ function DeviceList({
         setExcludeSoldout={setExcludeSoldout}
         showPrice={showPrice}
         setShowPrice={setShowPrice}
-        sortbyDir={sortbyDir}
-        setSortbyDir={setSortbyDir}
         search={search}
         onChangeSearch={onChangeSearch}
       />
@@ -91,6 +85,7 @@ function DeviceList({
                   <LaunchingDeviceListItem
                     key={`${index}-${data.serialNumber}`}
                     data={data}
+                    showPrice={showPrice}
                     onClickDetail={handleClickDetail}
                   />
                 ) : (

--- a/src/components/device/DeviceListFileterContents.js
+++ b/src/components/device/DeviceListFileterContents.js
@@ -4,12 +4,16 @@ export const SORT_TYPE = [
     value: 'launch',
   },
   {
-    name: '실구매가순',
+    name: '실구매가 낮은순',
     value: 'purchase',
   },
   {
-    name: '정상가순',
-    value: 'price',
+    name: '정상가 낮은순',
+    value: 'priceasc',
+  },
+  {
+    name: '정상가 높은순',
+    value: 'pricedes',
   },
 ];
 

--- a/src/components/device/DeviceListHeader.js
+++ b/src/components/device/DeviceListHeader.js
@@ -1,7 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { SORT_TYPE } from './DeviceListFileterContents';
-import useInput from '../../lib/hooks/useInput';
 
 import { styled } from '@mui/system';
 import {
@@ -23,8 +21,6 @@ import {
   Search,
   CheckCircle,
   CheckCircleOutline,
-  TrendingUp,
-  TrendingDown,
 } from '@mui/icons-material';
 
 const DeviceListHeaderBlock = styled('div')({
@@ -66,13 +62,12 @@ const StyledSortWrapper = styled('div')(({ theme }) => ({
   '& .MuiButtonBase-root.MuiListItem-root:hover': {
     background: 'none',
     color: theme.palette.prime,
+    svg: {
+      color: theme.palette.prime,
+    },
   },
   '& .MuiListItemIcon-root': {
     marginLeft: 5,
-  },
-  '& .MuiListItemIcon-root:hover': {
-    background: theme.palette.gray2,
-    borderRadius: '100%',
   },
 }));
 
@@ -86,7 +81,6 @@ const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
   },
 }));
 
-// TODO - options 적용
 function DeviceListHeader({
   count,
   searchParams,
@@ -95,12 +89,9 @@ function DeviceListHeader({
   setExcludeSoldout,
   showPrice,
   setShowPrice,
-  sortbyDir,
-  setSortbyDir,
   search,
   onChangeSearch,
 }) {
-  // const [sortDreiction, setSortDirection] = useState(true); // 정렬 기준 (true : 내림차순, false : 오름차순)
   const [anchorEl, setAnchorEl] = useState(null);
   const [selectedIndex, setSelectedIndex] = useState(
     (searchParams.get('sortby') &&
@@ -117,18 +108,12 @@ function DeviceListHeader({
     const data = SORT_TYPE[index].value;
     setSelectedIndex(index);
     setAnchorEl(null);
-    setSortbyDir(true);
-
     onChangeFilter('sortby', data);
   };
 
   const handleClose = () => {
     setAnchorEl(null);
   };
-
-  const handleChangeSortDirection = useCallback(() => {
-    setSortbyDir((prev) => !prev);
-  }, [setSortbyDir]);
 
   return (
     <DeviceListHeaderBlock>
@@ -177,11 +162,10 @@ function DeviceListHeader({
               id="lock-button"
               aria-haspopup="listbox"
               aria-controls="lock-menu"
-              aria-expanded={open ? 'true' : undefined}>
-              <ListItemText primary={SORT_TYPE[selectedIndex].name} onClick={handleClickListItem} />
-              <ListItemIcon onClick={handleChangeSortDirection}>
-                {sortbyDir ? <TrendingUp /> : <TrendingDown />}
-              </ListItemIcon>
+              aria-expanded={open ? 'true' : undefined}
+              onClick={handleClickListItem}>
+              <ListItemText primary={SORT_TYPE[selectedIndex].name} />
+              <ListItemIcon>{anchorEl ? <ExpandLess /> : <ExpandMore />}</ListItemIcon>
             </ListItem>
           </List>
           <Menu

--- a/src/components/device/compare/DeviceCompareItem.js
+++ b/src/components/device/compare/DeviceCompareItem.js
@@ -59,7 +59,10 @@ function DeviceCompareItem({ device, isLink, onClickRemove, isModal }) {
 
   const handleGoDetail = () => {
     if (isLink) {
-      navigate(`./${device?.serialNumber}`);
+      navigate({
+        pathname: `./${device.serialNumber}`,
+        search: `?id=${device.id}`,
+      });
     }
   };
   return (

--- a/src/components/device/launching/LaunchingDeviceListItem.js
+++ b/src/components/device/launching/LaunchingDeviceListItem.js
@@ -77,6 +77,7 @@ const ItemColorWrapper = styled(Box)(({ theme }) => ({
 }));
 
 const ItemInfoWrapper = styled(Box)({
+  flex: 1,
   padding: '1.5rem',
   '& .p-name': {
     fontSize: '1.25rem',
@@ -119,7 +120,7 @@ const ItemCompareWrapper = styled(Box)(({ theme }) => ({
   },
 }));
 
-function LaunchingDeviceListItem({ data, onClickDetail }) {
+function LaunchingDeviceListItem({ data, showPrice, onClickDetail }) {
   const [cIdx, setCIdx] = useState(0);
 
   const handleClickColor = (idx) => {
@@ -154,10 +155,11 @@ function LaunchingDeviceListItem({ data, onClickDetail }) {
         </div>
         <div>
           <div className="p-price-sub">
-            <div>준비중</div>
-            <div>준비중</div>
+            {showPrice && (
+              <div className="origin-price">정상가 {PriceFormatter(data?.price || 0)}원</div>
+            )}
           </div>
-          <div className="p-price">준비중</div>
+          <div className="p-price">출시예정</div>
         </div>
       </ItemInfoWrapper>
       <Divider />

--- a/src/components/modal/DeviceCompareModal.js
+++ b/src/components/modal/DeviceCompareModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import classnames from 'classnames';
 

--- a/src/components/modal/DeviceCompareModal.js
+++ b/src/components/modal/DeviceCompareModal.js
@@ -82,9 +82,12 @@ function DeviceCompareModal({ open, setOpen }) {
     }
   };
 
-  const handleClickRemove = useCallback((id) => {
-    dispatch(devicesActions.removeComparison(id));
-  }, []);
+  const handleClickRemove = useCallback(
+    (id) => {
+      dispatch(devicesActions.removeComparison(id));
+    },
+    [dispatch],
+  );
 
   return (
     <DeviceCompareModalBlock open={open} onClose={handleClose} z>

--- a/src/modules/actions/devicesSlice.js
+++ b/src/modules/actions/devicesSlice.js
@@ -5,7 +5,8 @@ import { FILTER_DATA } from '../../components/device/DeviceListFileterContents';
 const ALL = 'all';
 const LAUNCH = 'launch';
 const PURCHASE = 'purchase';
-const PRICE = 'price';
+const PRICEASC = 'priceasc';
+const PRICEDES = 'pricedes';
 const ETC = '기타';
 const SAMSUNG = '삼성';
 const APPLE = '애플';
@@ -86,7 +87,6 @@ export const filteredDevices = (
   company,
   storage,
   f_sortby,
-  f_sortbyDir,
   excludeSoldout,
   search,
 ) => {
@@ -127,20 +127,16 @@ export const filteredDevices = (
 
   if (!f_sortby || f_sortby === LAUNCH) {
     // 출시일 순
-    devicesWithPrice.sort((a, b) =>
-      f_sortbyDir
-        ? new Date(b.launchedDate) - new Date(a.launchedDate)
-        : new Date(a.launchedDate) - new Date(b.launchedDate),
-    );
+    devicesWithPrice.sort((a, b) => new Date(b.launchedDate) - new Date(a.launchedDate));
   } else if (f_sortby === PURCHASE) {
     // 실구매가 순
-    devicesWithPrice.sort((a, b) =>
-      f_sortbyDir
-        ? a.ddevicePrice + a.dplanPrice - (b.ddevicePrice + b.dplanPrice)
-        : b.ddevicePrice + b.dplanPrice - (a.ddevicePrice + a.dplanPrice),
+    devicesWithPrice.sort(
+      (a, b) => a.ddevicePrice + a.dplanPrice - (b.ddevicePrice + b.dplanPrice),
     );
-  } else if (f_sortby === PRICE) {
-    devicesWithPrice.sort((a, b) => (f_sortbyDir ? a.price - b.price : b.price - a.price));
+  } else if (f_sortby === PRICEASC) {
+    devicesWithPrice.sort((a, b) => a.price - b.price);
+  } else if (f_sortby === PRICEDES) {
+    devicesWithPrice.sort((a, b) => b.price - a.price);
   }
 
   // TODO - regex로 수정

--- a/src/pages/product/DeviceListPage.js
+++ b/src/pages/product/DeviceListPage.js
@@ -37,7 +37,6 @@ function DeviceListPage({ networkType }) {
   const f_storage = searchParams.getAll('storage');
   const f_sortby = searchParams.get('sortby');
 
-  const [sortbyDir, setSortbyDir] = useState(true);
   const [excludeSoldout, setExcludeSoldout] = useState(false);
   const [showPrice, setShowPrice] = useState(false);
   const [search, handleChangeSearch, setSearch] = useInput('');
@@ -57,7 +56,6 @@ function DeviceListPage({ networkType }) {
       f_company,
       f_storage,
       f_sortby,
-      sortbyDir,
       excludeSoldout,
       search,
     ),
@@ -69,8 +67,6 @@ function DeviceListPage({ networkType }) {
   const launchingDevices = useSelector((state) => state.devices.launchingDevices);
 
   useEffect(() => {
-    // 요금제 정보 불러오기
-    // dispatch(planActions.getPlanList(networkType));
     // 네트워크별 단말기 리스트 불러오기
     dispatch(
       devicesActions.getDevice({
@@ -185,8 +181,6 @@ function DeviceListPage({ networkType }) {
           showPrice={showPrice}
           setShowPrice={setShowPrice}
           sortby={f_sortby}
-          sortbyDir={sortbyDir}
-          setSortbyDir={setSortbyDir}
           search={search}
           onChangeSearch={handleChangeSearch}
         />


### PR DESCRIPTION
## 📌 개발 내용
- resolve #102 
- 상품 페이지 리스트 정렬 방향 버튼 및 출시 예정 단말기 디자인 수정
  <br>

## 💻  변경 내용
-정렬 버튼을 메뉴 드롭바로만 선택하도록 변경했습니다.
- 출시 예정 단말기의 월 휴대폰 요금, 월 통신료 요금 구간을 제외했습니다. 
- 출시 예정 단말기의 문구를 수정했습니다. (준비중 -> 출시예정)
- 출시 예정 단말기에 정상가 문구를 추가했습니다.
- scrollTop의 색상을 투명에서 불투명으로 변경했습니다.
  <br>

## ✅ PR Point
![image](https://user-images.githubusercontent.com/48594896/188304522-3417a56b-e8a6-4014-8726-6fccb2854648.png)
![image](https://user-images.githubusercontent.com/48594896/188304530-6edb6286-1a16-41b4-87e3-b2d7da04185c.png)
        
